### PR TITLE
Add lerna with basic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 ## Tools
 
+- [lerna](https://github.com/lerna/lerna) for publishing many NPM packages from a monorepo.
 - [commitlint](https://commitlint.js.org) enforces commit linting. Currently set up to enforce the [Conventional Commits](https://www.conventionalcommits.org) specification.
 - [husky](https://typicode.github.io/husky) for git hooks.

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,12 @@
+{
+  "packages": ["packages/*"],
+  "version": "independent",
+  "command": {
+    "publish": {
+      "ignoreChanges": ["*.md"],
+      "message": "chore(release): publish"
+    }
+  },
+  "hoist": true,
+  "stream": true
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.0.2",
     "@commitlint/config-conventional": "^16.0.0",
-    "husky": "^7.0.4"
+    "husky": "^7.0.4",
+    "lerna": "^4.0.0"
   }
 }


### PR DESCRIPTION
Adds the [lerna](https://github.com/lerna/lerna) package with the following setup:

```javascript
{
  // All packages will be nested under packages/ dir
  "packages": ["packages/*"],

  // Package versions are independent of each other
  // https://github.com/lerna/lerna#independent-mode
  "version": "independent",

  "command": {

    // Config for `lerna publish`
    "publish": {
      // Don't trigger package publish if just *.md files have changed
      "ignoreChanges": ["*.md"],
      // Commit message needs to follow conventional commits (previously set up)
      "message": "chore(release): publish"
    }
  },

  // Hoist common dependencies for performance
  // https://github.com/lerna/lerna/blob/main/doc/hoist.md
  // Will use eslint-plugin-import to help prevent any issues from hoisting.
  "hoist": true,

  // Stream logs coming from packages
  "stream": true
}
```